### PR TITLE
added receiveRecover for persistence

### DIFF
--- a/src/Phluxor/Persistence/Message/ReplayCompleted.php
+++ b/src/Phluxor/Persistence/Message/ReplayCompleted.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace Phluxor\Persistence\Message;
 
-final class ReplayComplete
+final class ReplayCompleted
 {
 }

--- a/src/Phluxor/Persistence/PersistentInterface.php
+++ b/src/Phluxor/Persistence/PersistentInterface.php
@@ -32,4 +32,12 @@ interface PersistentInterface
     public function recovering(): bool;
 
     public function name(): string;
+
+    /**
+     * @param mixed $message
+     * @return void
+     */
+    public function receiveRecover(
+        mixed $message
+    ): void;
 }

--- a/tests/Test/Persistence/Messages.php
+++ b/tests/Test/Persistence/Messages.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Persistence;
+
+final class Messages
+{
+}


### PR DESCRIPTION
# Added receiveRecover method

```php
class PersistenceActor implements ActorSystem\Message\ActorInterface, PersistentInterface 
{
    use Mixin;

    public function receive(ActorSystem\Context\ContextInterface $context): void
    {
        // receive all message
    }

    public function receiveRecover(mixed $message): void
    {
        // recovering message
    }
}
```