### PR TITLE
Add phpstan.neon to export-ignore in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,6 +2,7 @@
 /.gitignore export-ignore
 /.github export-ignore
 /.composer.lock export-ignore
+/phpstan.neon export-ignore
 /phpunit.xml export-ignore
 /phpcs.xml export-ignore
 /tests export-ignore


### PR DESCRIPTION
- Currently, The archive targets other than src/ are as follow

```
gh api repos/ytake/phluxor/tarball/HEAD | tar -tzf - | cut -d/ -f2- | sed '/^$/d' | grep -v src/
LICENSE
README.md
composer.json
phpstan.neon
protobuf/
protobuf/actor.proto
protobuf/readme.md
protobuf/router.proto
```

- With this PR, The archive targets other than src/ will be as follows:
```
gh api repos/sasezaki/phluxor/tarball/patch-1 | tar -tzf - | cut -d/ -f2- | sed '/^$/d' | grep -v src/
LICENSE
README.md
composer.json
protobuf/
protobuf/actor.proto
protobuf/readme.md
protobuf/router.proto
```